### PR TITLE
[LBSD-2818] - Admin checkbox is missing and command adjustment

### DIFF
--- a/apps/auth/db/commands.py
+++ b/apps/auth/db/commands.py
@@ -35,11 +35,11 @@ class CreateUserCommand(superdesk.Command):
         superdesk.Option('--email', '-e', dest='email', required=True),
         superdesk.Option('--admin', '-a', dest='admin', required=False, action='store_true'),
         superdesk.Option('--support', '-s', dest='support', required=False, action='store_true'),
-        superdesk.Option('--firstname', '-fn', dest='firstname', type=str),
-        superdesk.Option('--lastname', '-ln', dest='lastname', type=str),
+        superdesk.Option('--firstname', '-fn', dest='firstname', required=True, type=str),
+        superdesk.Option('--lastname', '-ln', dest='lastname', required=True, type=str),
     )
 
-    def run(self, username, password, email, admin=False, support=False, **kwargs):
+    def run(self, username, password, email, firstname, lastname, admin=False, support=False, **kwargs):
 
         # force type conversion to boolean
         user_type = 'administrator' if admin else 'user'
@@ -51,20 +51,11 @@ class CreateUserCommand(superdesk.Command):
             'user_type': user_type,
             'is_active': admin,
             'is_support': support,
-            'needs_activation': not admin
+            'needs_activation': not admin,
+            'firstname': firstname,
+            'lastname': lastname,
+            'display_name': f'{firstname} {lastname}'
         }
-
-        first_name = kwargs.get('firstname', '')
-        last_name = kwargs.get('lastname', '')
-
-        if first_name:
-            userdata['first_name'] = first_name
-
-        if last_name:
-            userdata['last_name'] = last_name
-
-        if first_name or last_name:
-            userdata['display_name'] = '{0} {1}'.format(first_name, last_name)
 
         with app.test_request_context('/users', method='POST'):
             if userdata.get('password', None) and not is_hashed(userdata.get('password')):


### PR DESCRIPTION
### Purpose

This PR adjusts the command for creating users so that the first and last name are required. This helps align the command with the UI flow. Also, this prevents users first and last names from being empty when modified like when setting a support user.

### What has changed
- Require `firstname` and `lastname` in CreateUserCommand

### Steps to test
1. Run Liveblog
2. Create a new user on the terminal.
```
$ python3 manage.py users:create -u adminTwo -p adminTwo -fn Admin -ln Two -e 'adminTwo@example.com' ;
```
3. Log into the Editor with the username and password.
4. Navigate to User Management and observe the user has their first and last name.
5. Modify the user on the terminal.
```
$ python3 manage.py users:modify --username adminTwo --support True
```
6. Navigate to User Management and observe the user retains their first and last name.

Resolves: [LBSD-2818](https://sofab.atlassian.net/browse/LBSD-2818)

_Note: This PR is for the liveblog_custom branch used in Liveblog_

[LBSD-2818]: https://sofab.atlassian.net/browse/LBSD-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ